### PR TITLE
chore: #12 - Add documentation deployment status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,8 @@
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![mypy](https://img.shields.io/badge/mypy-checked-blue)](http://mypy-lang.org/)
 [![Python 3.12](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/downloads/release/python-312/)
+[![Deploy Documentation](https://github.com/Lubricate-AI/lubrikit/actions/workflows/docs.yml/badge.svg)](https://github.com/Lubricate-AI/lubrikit/actions/workflows/docs.yml)
 
 SDK for building Collection, Ingestion, and Processing data pipelines.
+
+Please read the [documentation](https://lubricate-ai.github.io/lubrikit/).


### PR DESCRIPTION
# Pull Request

## INFO

- Add a status badge for the Documentation Deployment Github Action workflow to the `README`
- Add a link to the documentation to the `README`

## REFERENCES

- Related issue(s):
  - Closes #12
- External resources:
  - [Adding a workflow status badge](https://docs.github.com/en/actions/how-tos/monitor-workflows/add-a-status-badge)
