### PR TITLE
#15 - Rename S3Client to StorageClient

### DIFF
--- a/lubrikit/base/storage/__init__.py
+++ b/lubrikit/base/storage/__init__.py
@@ -1,3 +1,3 @@
-from .s3_client import S3Client
+from .s3_client import StorageClient
 
-__all__ = ["S3Client"]
+__all__ = ["StorageClient"]

--- a/lubrikit/base/storage/s3_client.py
+++ b/lubrikit/base/storage/s3_client.py
@@ -7,7 +7,7 @@ import s3fs  # type: ignore
 logger = logging.getLogger(__name__)
 
 
-class S3Client:
+class StorageClient:
     chunk_size: int = 1024
     encoding: str = "utf-8"
 

--- a/tests/base/storage/test_client.py
+++ b/tests/base/storage/test_client.py
@@ -4,34 +4,34 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from lubrikit.base.storage import S3Client
+from lubrikit.base.storage import StorageClient
 
 
 def test_base_path() -> None:
-    client = S3Client()
+    client = StorageClient()
     assert client.base_path == "s3://"
 
 
 @pytest.fixture
-def MockS3Client() -> type:
-    class MockS3Client(S3Client):
+def MockStorageClient() -> type:
+    class MockStorageClient(StorageClient):
         @cached_property
         def s3(self) -> Any:
             s3 = MagicMock()
             s3.exists.return_value = False
             return s3
 
-    return MockS3Client
+    return MockStorageClient
 
 
-def test_make_dirs(MockS3Client: type) -> None:
-    client = MockS3Client()
+def test_make_dirs(MockStorageClient: type) -> None:
+    client = MockStorageClient()
     client._make_dirs("test_folder/test_path")
 
     client.s3.mkdir.assert_called_once_with("test_folder/test_path")
 
 
-def test_write_not_implemented(MockS3Client: type) -> None:
-    client = MockS3Client()
+def test_write_not_implemented(MockStorageClient: type) -> None:
+    client = MockStorageClient()
     with pytest.raises(NotImplementedError):
         client.write("test data")


### PR DESCRIPTION
# Pull Request

## INFO

- Rename the `S3Client` object to `StorageClient`
  - We are initially building around S3 and the AWS ecosystem
  - We may want to support other storage types in the future, so generalizing now is a better idea

## REFERENCES

- Related issue(s):
  - Closes #15 