### PR TITLE
#18 - Specify Google-style docstrings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,4 +39,4 @@ coverage: ## Run tests with coverage report
 	uv run pytest --cov=$(SOURCE_PATH) --cov-report=term-missing $(TEST_PATH)
 
 docs: ## Generate documentation using pdoc
-	uv run pdoc -o docs $(SOURCE_PATH)
+	uv run pdoc -d google -o docs $(SOURCE_PATH)


### PR DESCRIPTION
# Pull Request

## INFO

- Specifies to **pdoc** that we are using Google-style docstrings
- This should improve parsing of the docstrings, yielding improved documentation

## REFERENCES

- Related issue(s):
  - Closes #18 