### PR TITLE
#22 - Add support for Google Workspace documents

### DIFF
--- a/lubrikit/extract/connectors/configs/google_drive_api/google_drive_api.py
+++ b/lubrikit/extract/connectors/configs/google_drive_api/google_drive_api.py
@@ -9,22 +9,28 @@ class GoogleDriveAPIConfig(BaseModel):
     validation and type checking.
 
     Attributes:
-        file_id (str): The unique identifier of the Google Drive file to
+        fileId (str): The unique identifier of the Google Drive file to
             access. This is a required field with a minimum length of 1
             character. The file ID can be found in the Google Drive URL
             when viewing a file.
             Example: "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms"
+        mimeType (str | None): The MIME type of the file. This is an
+            optional field that can be used to specify the format of the
+            file when downloading or exporting it. If not specified, the
+            default MIME type will be used.
+            Examples: "text/csv", "application/pdf"
 
     Example:
         >>> config = GoogleDriveAPIConfig(
-        ...     file_id="1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms"
+        ...     fileId="1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms"
         ... )
-        >>> print(config.file_id)
+        >>> print(config.fileId)
         1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms
     """
 
-    file_id: str = Field(
+    fileId: str = Field(
         min_length=1,
         description="The unique identifier of the Google Drive file to access. "
         "Found in the Google Drive URL when viewing a file.",
     )
+    mimeType: str | None = Field(default=None, description="The MIME type of the file.")

--- a/lubrikit/extract/connectors/google_drive_api.py
+++ b/lubrikit/extract/connectors/google_drive_api.py
@@ -37,10 +37,19 @@ class GoogleDriveAPIConnector(BaseConnector):
             Drive API calls. Initialized to None and set during
             connection establishment.
         config (GoogleDriveAPIConfig): Configuration object containing
-            the Google Drive file ID and other connection parameters.
+            the Google Drive file ID and other connection parameters. If
+            downloading a Google Workspace document (Google Docs,
+            Google Sheets, etc.), the `mimeType` field can be set to
+            specify the desired export format.
+        headers_cache (dict[str, str]): Cache for file metadata headers
+            like file name, last modified time, and content length. Used
+            to determine if the file has changed since the last download.
         retriable_exceptions (tuple[type[Exception], ...]): Tuple of
             exception types that should trigger retry logic. Includes
             HTTP errors, authentication failures, and network issues.
+        retry_config (RetryConfig | None): Configuration for retry
+            behavior when encountering retriable exceptions. If None,
+            default retry behavior is used.
         scopes (list[str]): (class attribute) The OAuth2 scopes required
             for Google Drive access. Contains
             ["https://www.googleapis.com/auth/drive"] for full Drive
@@ -223,13 +232,13 @@ class GoogleDriveAPIConnector(BaseConnector):
         }
 
         # Configure the file to download
-        config = GoogleDriveAPIConfig(file_id="[YOUR_FILE_ID]")
+        config = GoogleDriveAPIConfig(fileId="[YOUR_FILE_ID]")
 
         # Create connector instance
         connector = GoogleDriveAPIConnector(config=config, headers_cache=headers_cache)
 
         # Check for updates and get download info
-        headers, (stream, downloader) = connector.download()
+        headers, downloader = connector.download()
         print(headers)
 
         # Download file if there are updates
@@ -239,12 +248,6 @@ class GoogleDriveAPIConnector(BaseConnector):
                 status, done = downloader.next_chunk()
                 if status:
                     print(f"Download {int(status.progress() * 100)}%.")
-
-        # Save downloaded content to file
-        if stream:
-            with open(headers["file_name"], "wb") as f:
-                stream.seek(0)
-                f.write(stream.read())
         ```
 
     Note:
@@ -291,62 +294,9 @@ class GoogleDriveAPIConnector(BaseConnector):
             TimeoutError,  # Request timeout errors
         )
 
-        # Google API client resource for making Drive API calls
-        self.client: Resource | None = None
-
     @cached_property
-    def content_length(self) -> int:
-        """Get the content length of the file in Google Drive.
-
-        Returns:
-            int: Content length of the file.
-        """
-        if not self.client:
-            raise ValueError("Google Drive client is not initialized.")
-
-        return int(
-            self.client.files()  # type: ignore[attr-defined]
-            .get(fileId=self.config.file_id, fields="size")
-            .execute()
-            .get("size")
-        )
-
-    @cached_property
-    def file_name(self) -> str:
-        """Get the name of the file in Google Drive.
-
-        Returns:
-            str: Name of the file.
-        """
-        if not self.client:
-            raise ValueError("Google Drive client is not initialized.")
-
-        return str(
-            self.client.files()  # type: ignore[attr-defined]
-            .get(fileId=self.config.file_id, fields="name")
-            .execute()
-            .get("name")
-        )
-
-    @cached_property
-    def last_modified_at(self) -> str:
-        """When the file was updated in Google Drive.
-
-        Returns:
-            str: Datetime string for when the data source file was updated.
-        """
-        if not self.client:
-            raise ValueError("Google Drive client is not initialized.")
-
-        return str(
-            self.client.files()  # type: ignore[attr-defined]
-            .get(fileId=self.config.file_id, fields="modifiedTime")
-            .execute()
-            .get("modifiedTime", "")
-        )
-
-    def connect(self) -> Resource:
-        """Create a client that communicates to a Google API.
+    def client(self) -> Resource:
+        """A client that communicates to the Google Drive API.
 
         Returns:
             Resource: A Google API client resource.
@@ -365,47 +315,129 @@ class GoogleDriveAPIConnector(BaseConnector):
 
         return client  # type: ignore[no-any-return]
 
+    @cached_property
+    def content_length(self) -> int:
+        """Get the content length of the file in Google Drive.
+
+        Returns:
+            int: Content length of the file.
+        """
+        if not self.client:
+            raise ValueError("Google Drive client is not initialized.")
+
+        return int(
+            self.client.files()  # type: ignore[attr-defined]
+            .get(fileId=self.config.fileId, fields="size")
+            .execute()
+            .get("size")
+        )
+
+    @cached_property
+    def file_name(self) -> str:
+        """Get the name of the file in Google Drive.
+
+        Returns:
+            str: Name of the file.
+        """
+        if not self.client:
+            raise ValueError("Google Drive client is not initialized.")
+
+        return str(
+            self.client.files()  # type: ignore[attr-defined]
+            .get(fileId=self.config.fileId, fields="name")
+            .execute()
+            .get("name")
+        )
+
+    @cached_property
+    def last_modified_at(self) -> str:
+        """When the file was updated in Google Drive.
+
+        Returns:
+            str: Datetime string for when the data source file was updated.
+        """
+        if not self.client:
+            raise ValueError("Google Drive client is not initialized.")
+
+        return str(
+            self.client.files()  # type: ignore[attr-defined]
+            .get(fileId=self.config.fileId, fields="modifiedTime")
+            .execute()
+            .get("modifiedTime", "")
+        )
+
+    @cached_property
+    def supported_mime_types(self) -> list[str]:
+        """Get the list of supported MIME types for exporting.
+
+        Mime types are used to specify the format in which files
+        should be exported from Google Drive. This is particularly
+        useful when downloading Google Workspace documents like
+        Google Docs, Sheets, or Slides. For example, you can
+        export a Google Doc as a PDF or a Google Sheet as a CSV.
+
+        This method retrieves the supported MIME types for exporting
+        files from Google Drive by querying the `about.get` API endpoint
+        with `exportFormats`.
+
+        Returns:
+            list[str]: A list of supported MIME types for file exports.
+        """
+        if not self.client:
+            raise ValueError("Google Drive client is not initialized.")
+
+        about_info = (
+            self.client.files()  # type: ignore[attr-defined]
+            .get(fileId=self.config.fileId, fields="exportLinks")
+            .execute()
+        )
+        export_links = about_info.get("exportLinks", {})
+
+        # Collect all supported MIME types for the given file ID
+        supported_mime_types = list(export_links.keys())
+
+        return sorted(supported_mime_types)
+
     def _check(self) -> dict[str, Any] | None:
         """Check the Google Drive resource without downloading it.
 
         Returns:
             dict[str, Any]: A dictionary containing the updated headers cache.
         """
-        try:
-            self.client = self.connect()
-            return self._prepare_cache()
-        except Exception as e:
-            logger.error(f"Failed to connect to Google Drive API: {e}")
-            return None
+        logger.info(f"Checking {self.file_name} in Google Drive...")
 
-    def _download(
-        self,
-    ) -> tuple[
-        dict[str, Any] | None, tuple[io.BytesIO | None, MediaIoBaseDownload | None]
-    ]:
+        self._validate_mime_type()
+        return self._prepare_cache()
+
+    def _download(self) -> tuple[dict[str, Any] | None, MediaIoBaseDownload | None]:
         """Download the Google Drive file.
 
         Returns:
             tuple[dict[str, Any] | None, MediaIoBaseDownload]: A tuple
                 containing the file metadata and the download stream.
         """
-        self.client = self.connect()
+        logger.info(f"Downloading {self.file_name} from Google Drive...")
+        self._validate_mime_type()
         new_headers = self._prepare_cache()
 
         # If resource unchanged
         if all(
-            self.headers_cache.get(k) == new_headers.get(k)
-            for k in ["last_modified", "content_length"]
+            self.headers_cache.get(k) == new_headers.get(k) for k in new_headers.keys()
         ):
             logger.info("No new version. Skipping download.")
-            return new_headers, (None, None)
+            return new_headers, None
 
-        logger.info(f"Downloading file {self.config.file_id} from Google Drive...")
-        request = self.client.files().get_media(fileId=self.config.file_id)  # type: ignore[attr-defined]
-        stream = io.BytesIO()
-        downloader = MediaIoBaseDownload(stream, request)
+        # If resource changed, prepare to download
+        request_func = (
+            self.client.files().get_media  # type: ignore[attr-defined]
+            if self.config.mimeType is None
+            else self.client.files().export_media  # type: ignore[attr-defined]
+        )
+        request = request_func(**self.config.model_dump(exclude_none=True))
+        fh = io.FileIO(self.file_name, mode="wb")
+        downloader = MediaIoBaseDownload(fh, request)
 
-        return new_headers, (stream, downloader)
+        return new_headers, downloader
 
     def _prepare_cache(self) -> dict[str, str]:
         """Prepare cache metadata from the Google Drive file.
@@ -420,3 +452,19 @@ class GoogleDriveAPIConnector(BaseConnector):
         }
 
         return cache
+
+    def _validate_mime_type(self) -> None:
+        """Validate the MIME type if provided in the config.
+
+        Raises:
+            ValueError: If the provided MIME type is not supported by
+                Google Drive.
+        """
+        if (
+            self.config.mimeType is not None
+            and self.config.mimeType not in self.supported_mime_types
+        ):
+            raise ValueError(
+                f"Unsupported MIME type '{self.config.mimeType}'. "
+                f"Supported types: {', '.join(self.supported_mime_types)}"
+            )

--- a/tests/extract/connectors/configs/google_drive_api/test_google_drive_api.py
+++ b/tests/extract/connectors/configs/google_drive_api/test_google_drive_api.py
@@ -4,16 +4,16 @@ from pydantic import ValidationError
 from lubrikit.extract.connectors.configs.google_drive_api import GoogleDriveAPIConfig
 
 
-def test_valid_file_id() -> None:
-    """Test GoogleDriveAPIConfig with valid file_id."""
-    file_id = "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms"
-    config = GoogleDriveAPIConfig(file_id=file_id)
+def test_valid_fileId() -> None:
+    """Test GoogleDriveAPIConfig with valid fileId."""
+    fileId = "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms"
+    config = GoogleDriveAPIConfig(fileId=fileId)
 
-    assert config.file_id == file_id
+    assert config.fileId == fileId
 
 
 @pytest.mark.parametrize(
-    "file_id",
+    "fileId",
     [
         "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms",  # Standard file ID
         "1n6RHOzzrpAXSRdVwpLNGIwVxcI4Pqzy_",  # Short file ID
@@ -22,31 +22,31 @@ def test_valid_file_id() -> None:
         "123-abc_DEF",  # File ID with special characters
     ],
 )
-def test_valid_file_id_formats(file_id: str) -> None:
+def test_valid_fileId_formats(fileId: str) -> None:
     """Test GoogleDriveAPIConfig accepts various valid file ID formats."""
-    config = GoogleDriveAPIConfig(file_id=file_id)
-    assert config.file_id == file_id
+    config = GoogleDriveAPIConfig(fileId=fileId)
+    assert config.fileId == fileId
 
 
-def test_file_id_required() -> None:
-    """Test that file_id field is required."""
+def test_fileId_required() -> None:
+    """Test that fileId field is required."""
     with pytest.raises(ValidationError) as exc_info:
         GoogleDriveAPIConfig()  # type: ignore[call-arg]
 
     errors = exc_info.value.errors()
     assert len(errors) == 1
-    assert errors[0]["loc"] == ("file_id",)
+    assert errors[0]["loc"] == ("fileId",)
     assert "missing" in errors[0]["type"]
 
 
-def test_invalid_file_id_empty_string() -> None:
-    """Test that file_id field rejects empty string."""
+def test_invalid_fileId_empty_string() -> None:
+    """Test that fileId field rejects empty string."""
     with pytest.raises(ValidationError) as exc_info:
-        GoogleDriveAPIConfig(file_id="")
+        GoogleDriveAPIConfig(fileId="")
 
     errors = exc_info.value.errors()
     assert len(errors) == 1
-    assert errors[0]["loc"] == ("file_id",)
+    assert errors[0]["loc"] == ("fileId",)
     assert (
         "string_too_short" in errors[0]["type"]
         or "at least 1 character" in errors[0]["msg"]
@@ -54,28 +54,28 @@ def test_invalid_file_id_empty_string() -> None:
 
 
 @pytest.mark.parametrize(
-    "whitespace_file_id",
+    "whitespace_fileId",
     [
         "   ",  # Whitespace only
         "\t",  # Tab character
         "\n",  # Newline character
     ],
 )
-def test_whitespace_file_id_allowed(whitespace_file_id: str) -> None:
-    """Test file_id field allows whitespace-only strings (Pydantic behavior)."""
+def test_whitespace_fileId_allowed(whitespace_fileId: str) -> None:
+    """Test fileId field allows whitespace-only strings (Pydantic behavior)."""
     # Note: Pydantic's min_length counts whitespace characters, so these are valid
-    config = GoogleDriveAPIConfig(file_id=whitespace_file_id)
-    assert config.file_id == whitespace_file_id
+    config = GoogleDriveAPIConfig(fileId=whitespace_fileId)
+    assert config.fileId == whitespace_fileId
 
 
-def test_file_id_type_validation() -> None:
-    """Test that file_id field rejects non-string types."""
+def test_fileId_type_validation() -> None:
+    """Test that fileId field rejects non-string types."""
     with pytest.raises(ValidationError) as exc_info:
-        GoogleDriveAPIConfig(file_id=123)
+        GoogleDriveAPIConfig(fileId=123)
 
     errors = exc_info.value.errors()
     assert len(errors) == 1
-    assert errors[0]["loc"] == ("file_id",)
+    assert errors[0]["loc"] == ("fileId",)
     assert (
         "string_type" in errors[0]["type"]
         or "Input should be a valid string" in errors[0]["msg"]

--- a/tests/extract/connectors/test_google_drive_api.py
+++ b/tests/extract/connectors/test_google_drive_api.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
@@ -26,7 +27,7 @@ def headers_cache() -> dict[str, str]:
 @pytest.fixture
 def google_drive_config() -> GoogleDriveAPIConfig:
     """Sample GoogleDrive configuration."""
-    return GoogleDriveAPIConfig(file_id="1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms")
+    return GoogleDriveAPIConfig(fileId="1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms")
 
 
 @pytest.fixture
@@ -134,6 +135,20 @@ def test_initialization_default(
 ) -> None:
     """Test GoogleDriveAPIConnector initialization with default settings."""
     mock_service_account_instance = Mock()
+    # Mock the model_dump() method that the client property will call
+    mock_service_account_instance.model_dump.return_value = {
+        "type": "service_account",
+        "project_id": "test-project",
+        "private_key_id": "test-key-id",
+        "private_key": "-----BEGIN PRIVATE KEY-----\ntest-key\n-----END PRIVATE KEY-----\n",
+        "client_email": "test@test-project.iam.gserviceaccount.com",
+        "client_id": "123456789012345678901",
+        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+        "token_uri": "https://oauth2.googleapis.com/token",
+        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+        "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test%40test-project.iam.gserviceaccount.com",
+        "universe_domain": "googleapis.com",
+    }
     mock_service_account_info.return_value = mock_service_account_instance
 
     connector = GoogleDriveAPIConnector(
@@ -145,7 +160,8 @@ def test_initialization_default(
     assert connector.service_account_info == mock_service_account_instance
     assert connector.retry_config.timeout == 10.0
     assert connector.retry_config.max_retries == 3
-    assert connector.client is None
+    # Note: client is now a cached_property that creates a real client when accessed
+    # We don't test it directly here to avoid authentication issues
 
 
 def test_initialization_with_service_account(
@@ -214,41 +230,6 @@ def test_retriable_exceptions_configuration(connector: GoogleDriveAPIConnector) 
     assert connector.retriable_exceptions == expected_exceptions
 
 
-@patch("lubrikit.extract.connectors.google_drive_api.build")
-@patch("lubrikit.extract.connectors.google_drive_api.service_account")
-def test_connect_method(
-    mock_service_account: Mock,
-    mock_build: Mock,
-    connector: GoogleDriveAPIConnector,
-    mock_google_api_client: Mock,
-) -> None:
-    """Test the connect method creates Google Drive client."""
-    # Setup mocks
-    mock_credentials = Mock()
-    mock_scoped_credentials = Mock()
-    mock_service_account.Credentials.from_service_account_info.return_value = (
-        mock_credentials
-    )
-    mock_credentials.with_scopes.return_value = mock_scoped_credentials
-    mock_build.return_value = mock_google_api_client
-
-    # Call connect method
-    result = connector.connect()
-
-    # Verify calls
-    mock_service_account.Credentials.from_service_account_info.assert_called_once_with(
-        info=connector.service_account_info.model_dump()
-    )
-    mock_credentials.with_scopes.assert_called_once_with(GoogleDriveAPIConnector.scopes)
-    mock_build.assert_called_once_with(
-        GoogleDriveAPIConnector.api_name,
-        GoogleDriveAPIConnector.api_version,
-        credentials=mock_scoped_credentials,
-    )
-
-    assert result == mock_google_api_client
-
-
 def test_content_length_property(
     connector: GoogleDriveAPIConnector, mock_google_api_client: Mock
 ) -> None:
@@ -259,14 +240,31 @@ def test_content_length_property(
 
     assert content_length == 1024
     mock_google_api_client.files().get.assert_called_once_with(
-        fileId=connector.config.file_id, fields="size"
+        fileId=connector.config.fileId, fields="size"
     )
 
 
-def test_content_length_no_client(connector: GoogleDriveAPIConnector) -> None:
-    """Test content_length property raises error when client not initialized."""
-    with pytest.raises(ValueError, match="Google Drive client is not initialized"):
-        _ = connector.content_length
+@patch("lubrikit.extract.connectors.google_drive_api.build")
+@patch("lubrikit.extract.connectors.google_drive_api.service_account")
+def test_content_length_with_mocked_client(
+    mock_service_account: Mock, mock_build: Mock, connector: GoogleDriveAPIConnector
+) -> None:
+    """Test content_length property with mocked Google API client."""
+    # Mock the service account credentials
+    mock_credentials = Mock()
+    mock_service_account.Credentials.from_service_account_info.return_value = (
+        mock_credentials
+    )
+    mock_credentials.with_scopes.return_value = mock_credentials
+
+    # Mock the Google API client
+    mock_client = Mock()
+    mock_build.return_value = mock_client
+    mock_client.files().get().execute.return_value = {"size": "2048"}
+
+    content_length = connector.content_length
+
+    assert content_length == 2048
 
 
 def test_file_name_property(
@@ -279,14 +277,31 @@ def test_file_name_property(
 
     assert file_name == "test_file.csv"
     mock_google_api_client.files().get.assert_called_once_with(
-        fileId=connector.config.file_id, fields="name"
+        fileId=connector.config.fileId, fields="name"
     )
 
 
-def test_file_name_no_client(connector: GoogleDriveAPIConnector) -> None:
-    """Test file_name property raises error when client not initialized."""
-    with pytest.raises(ValueError, match="Google Drive client is not initialized"):
-        _ = connector.file_name
+@patch("lubrikit.extract.connectors.google_drive_api.build")
+@patch("lubrikit.extract.connectors.google_drive_api.service_account")
+def test_file_name_with_mocked_client(
+    mock_service_account: Mock, mock_build: Mock, connector: GoogleDriveAPIConnector
+) -> None:
+    """Test file_name property with mocked Google API client."""
+    # Mock the service account credentials
+    mock_credentials = Mock()
+    mock_service_account.Credentials.from_service_account_info.return_value = (
+        mock_credentials
+    )
+    mock_credentials.with_scopes.return_value = mock_credentials
+
+    # Mock the Google API client
+    mock_client = Mock()
+    mock_build.return_value = mock_client
+    mock_client.files().get().execute.return_value = {"name": "mocked_file.csv"}
+
+    file_name = connector.file_name
+
+    assert file_name == "mocked_file.csv"
 
 
 def test_last_modified_at_property(
@@ -299,51 +314,120 @@ def test_last_modified_at_property(
 
     assert last_modified == "2023-08-12T21:52:29.054Z"
     mock_google_api_client.files().get.assert_called_once_with(
-        fileId=connector.config.file_id, fields="modifiedTime"
+        fileId=connector.config.fileId, fields="modifiedTime"
     )
 
 
-def test_last_modified_at_no_client(connector: GoogleDriveAPIConnector) -> None:
-    """Test last_modified_at property raises error when client not initialized."""
-    with pytest.raises(ValueError, match="Google Drive client is not initialized"):
-        _ = connector.last_modified_at
+@patch("lubrikit.extract.connectors.google_drive_api.build")
+@patch("lubrikit.extract.connectors.google_drive_api.service_account")
+def test_last_modified_at_with_mocked_client(
+    mock_service_account: Mock, mock_build: Mock, connector: GoogleDriveAPIConnector
+) -> None:
+    """Test last_modified_at property with mocked Google API client."""
+    # Mock the service account credentials
+    mock_credentials = Mock()
+    mock_service_account.Credentials.from_service_account_info.return_value = (
+        mock_credentials
+    )
+    mock_credentials.with_scopes.return_value = mock_credentials
+
+    # Mock the Google API client
+    mock_client = Mock()
+    mock_build.return_value = mock_client
+    mock_client.files().get().execute.return_value = {
+        "modifiedTime": "2023-12-01T10:00:00.000Z"
+    }
+
+    last_modified = connector.last_modified_at
+
+    assert last_modified == "2023-12-01T10:00:00.000Z"
 
 
 @patch("lubrikit.extract.connectors.google_drive_api.logger")
+@patch("lubrikit.extract.connectors.google_drive_api.build")
+@patch("lubrikit.extract.connectors.google_drive_api.service_account")
 def test_check_success(
+    mock_service_account: Mock,
+    mock_build: Mock,
     mock_logger: Mock,
     connector: GoogleDriveAPIConnector,
-    mock_google_api_client: Mock,
 ) -> None:
     """Test _check method with successful connection."""
-    connector.client = None  # Start with no client
+    # Mock the service account credentials
+    mock_credentials = Mock()
+    mock_service_account.Credentials.from_service_account_info.return_value = (
+        mock_credentials
+    )
+    mock_credentials.with_scopes.return_value = mock_credentials
 
-    with patch.object(
-        connector, "connect", return_value=mock_google_api_client
-    ) as mock_connect:
-        with patch.object(
-            connector, "_prepare_cache", return_value={"test": "cache"}
-        ) as mock_prepare_cache:
-            result = connector._check()
+    # Mock the Google API client
+    mock_client = Mock()
+    mock_build.return_value = mock_client
 
-    assert result == {"test": "cache"}
-    mock_connect.assert_called_once()
-    mock_prepare_cache.assert_called_once()
+    # Set up separate mock objects for different API calls
+    mock_files = Mock()
+    mock_client.files.return_value = mock_files
+
+    # Mock file_name property call
+    mock_name_get = Mock()
+    mock_name_get.execute.return_value = {"name": "test_file.csv"}
+
+    # Mock last_modified_at property call
+    mock_modified_get = Mock()
+    mock_modified_get.execute.return_value = {
+        "modifiedTime": "2023-08-12T21:52:29.054Z"
+    }
+
+    # Mock content_length property call
+    mock_size_get = Mock()
+    mock_size_get.execute.return_value = {"size": "1605"}
+
+    # Mock supported_mime_types property call (for _validate_mime_type)
+    mock_export_get = Mock()
+    mock_export_get.execute.return_value = {"exportLinks": {}}
+
+    # Configure the mock to return different responses based on the fields parameter
+    def mock_get(**kwargs: Any) -> Any:
+        fields = kwargs.get("fields", "")
+        if fields == "name":
+            return mock_name_get
+        elif fields == "modifiedTime":
+            return mock_modified_get
+        elif fields == "size":
+            return mock_size_get
+        elif fields == "exportLinks":
+            return mock_export_get
+        else:
+            return Mock()
+
+    mock_files.get.side_effect = mock_get
+
+    result = connector._check()
+
+    assert result is not None
+    assert result["file_name"] == "test_file.csv"
+    assert result["last_modified"] == "2023-08-12T21:52:29.054Z"
+    assert result["content_length"] == "1605"
 
 
 @patch("lubrikit.extract.connectors.google_drive_api.logger")
+@patch("lubrikit.extract.connectors.google_drive_api.build")
+@patch("lubrikit.extract.connectors.google_drive_api.service_account")
 def test_check_failure(
+    mock_service_account: Mock,
+    mock_build: Mock,
     mock_logger: Mock,
     connector: GoogleDriveAPIConnector,
 ) -> None:
     """Test _check method with connection failure."""
-    with patch.object(connector, "connect", side_effect=Exception("Connection failed")):
-        result = connector._check()
-
-    assert result is None
-    mock_logger.error.assert_called_once_with(
-        "Failed to connect to Google Drive API: Connection failed"
+    # Mock service account to raise an exception
+    mock_service_account.Credentials.from_service_account_info.side_effect = Exception(
+        "Connection failed"
     )
+
+    # This should raise an exception since the client property will fail
+    with pytest.raises(Exception, match="Connection failed"):
+        _ = connector._check()
 
 
 def test_prepare_cache(
@@ -387,74 +471,103 @@ def test_prepare_cache_with_none_values(
 
 
 @patch("lubrikit.extract.connectors.google_drive_api.MediaIoBaseDownload")
-@patch("lubrikit.extract.connectors.google_drive_api.io.BytesIO")
+@patch("lubrikit.extract.connectors.google_drive_api.io.FileIO")
+@patch("lubrikit.extract.connectors.google_drive_api.build")
+@patch("lubrikit.extract.connectors.google_drive_api.service_account")
 def test_download_success_new_content(
-    mock_bytes_io: Mock,
+    mock_service_account: Mock,
+    mock_build: Mock,
+    mock_file_io: Mock,
     mock_media_download: Mock,
     connector: GoogleDriveAPIConnector,
-    mock_google_api_client: Mock,
 ) -> None:
     """Test _download method with successful download of new content."""
-    # Setup
-    mock_stream = Mock()
-    mock_bytes_io.return_value = mock_stream
+    # Mock the service account credentials
+    mock_credentials = Mock()
+    mock_service_account.Credentials.from_service_account_info.return_value = (
+        mock_credentials
+    )
+    mock_credentials.with_scopes.return_value = mock_credentials
+
+    # Mock the Google API client
+    mock_client = Mock()
+    mock_build.return_value = mock_client
+
+    # Setup file and download mocks
+    mock_file_handle = Mock()
+    mock_file_io.return_value = mock_file_handle
     mock_downloader = Mock()
     mock_media_download.return_value = mock_downloader
 
     # Mock different cache values to trigger download
     connector.headers_cache = {"last_modified": "old-date", "content_length": "500"}
 
-    with patch.object(connector, "connect", return_value=mock_google_api_client):
-        with patch.object(
-            connector,
-            "_prepare_cache",
-            return_value={"last_modified": "new-date", "content_length": "1024"},
-        ):
-            headers, (stream, downloader) = connector._download()
+    # Mock the properties that _prepare_cache calls
+    mock_client.files().get().execute.side_effect = [
+        {"name": "test_file.csv"},
+        {"modifiedTime": "new-date"},
+        {"size": "1024"},
+    ]
+
+    # Mock validation to pass
+    with patch.object(connector, "_validate_mime_type"):
+        headers, downloader = connector._download()
 
     # Verify results
-    assert headers == {"last_modified": "new-date", "content_length": "1024"}
-    assert stream == mock_stream
+    assert (headers or {}).get("file_name") == "test_file.csv"
+    assert (headers or {}).get("last_modified") == "new-date"
+    assert (headers or {}).get("content_length") == "1024"
     assert downloader == mock_downloader
 
-    # Verify API calls
-    mock_google_api_client.files().get_media.assert_called_once_with(
-        fileId=connector.config.file_id
-    )
-    mock_media_download.assert_called_once_with(
-        mock_stream, mock_google_api_client.files().get_media.return_value
-    )
 
-
+@patch("lubrikit.extract.connectors.google_drive_api.build")
+@patch("lubrikit.extract.connectors.google_drive_api.service_account")
 def test_download_no_new_version(
-    connector: GoogleDriveAPIConnector, mock_google_api_client: Mock
+    mock_service_account: Mock,
+    mock_build: Mock,
+    connector: GoogleDriveAPIConnector,
 ) -> None:
     """Test _download method when no new version is available."""
+    # Mock the service account credentials
+    mock_credentials = Mock()
+    mock_service_account.Credentials.from_service_account_info.return_value = (
+        mock_credentials
+    )
+    mock_credentials.with_scopes.return_value = mock_credentials
+
+    # Mock the Google API client
+    mock_client = Mock()
+    mock_build.return_value = mock_client
+
     # Setup cache with same values as will be returned
     connector.headers_cache = {
+        "file_name": "test_file.csv",
         "last_modified": "same-date",
         "content_length": "1024",
     }
 
-    with patch.object(connector, "connect", return_value=mock_google_api_client):
-        with patch.object(
-            connector,
-            "_prepare_cache",
-            return_value={"last_modified": "same-date", "content_length": "1024"},
-        ):
-            with patch(
-                "lubrikit.extract.connectors.google_drive_api.logger"
-            ) as mock_logger:
-                headers, (stream, downloader) = connector._download()
+    # Mock the properties that _prepare_cache calls to return same values
+    mock_client.files().get().execute.side_effect = [
+        {"name": "test_file.csv"},
+        {"modifiedTime": "same-date"},
+        {"size": "1024"},
+    ]
+
+    with patch("lubrikit.extract.connectors.google_drive_api.logger") as mock_logger:
+        with patch.object(connector, "_validate_mime_type"):
+            headers, downloader = connector._download()
 
     # Verify results
-    assert headers == {"last_modified": "same-date", "content_length": "1024"}
-    assert stream is None
+    assert (headers or {}).get("file_name") == "test_file.csv"
+    assert (headers or {}).get("last_modified") == "same-date"
+    assert (headers or {}).get("content_length") == "1024"
     assert downloader is None
 
     # Verify no download was attempted
-    mock_google_api_client.files().get_media.assert_not_called()
-    mock_logger.info.assert_called_once_with("No new version. Skipping download.")
+    mock_client.files().get_media.assert_not_called()
+    mock_client.files().export_media.assert_not_called()
+    # Check that the specific message was logged (among other info messages)
+    mock_logger.info.assert_any_call("No new version. Skipping download.")
 
 
 @pytest.mark.parametrize(
@@ -516,9 +629,9 @@ def test_cached_properties_are_cached(
     assert mock_google_api_client.files().get.call_count == 1
 
 
-def test_file_id_from_config(connector: GoogleDriveAPIConnector) -> None:
-    """Test that file_id is correctly taken from config."""
-    assert connector.config.file_id == "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms"
+def test_fileId_from_config(connector: GoogleDriveAPIConnector) -> None:
+    """Test that fileId is correctly taken from config."""
+    assert connector.config.fileId == "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms"
 
 
 @pytest.mark.parametrize(
@@ -546,50 +659,330 @@ def test_headers_cache_initialization(
     assert connector.headers_cache == expected_cache
 
 
+@patch("lubrikit.extract.connectors.google_drive_api.MediaIoBaseDownload")
+@patch("lubrikit.extract.connectors.google_drive_api.io.FileIO")
+@patch("lubrikit.extract.connectors.google_drive_api.build")
+@patch("lubrikit.extract.connectors.google_drive_api.service_account")
 def test_download_cache_comparison_logic(
-    connector: GoogleDriveAPIConnector, mock_google_api_client: Mock
+    mock_service_account: Mock,
+    mock_build: Mock,
+    mock_file_io: Mock,
+    mock_media_download: Mock,
+    connector: GoogleDriveAPIConnector,
 ) -> None:
     """Test the specific cache comparison logic in _download method."""
+    # Mock the service account credentials
+    mock_credentials = Mock()
+    mock_service_account.Credentials.from_service_account_info.return_value = (
+        mock_credentials
+    )
+    mock_credentials.with_scopes.return_value = mock_credentials
+
+    # Mock the Google API client
+    mock_client = Mock()
+    mock_build.return_value = mock_client
+    mock_downloader = Mock()
+    mock_media_download.return_value = mock_downloader
+    mock_file_handle = Mock()
+    mock_file_io.return_value = mock_file_handle
+
     # Test case 1: Different last_modified should trigger download
     connector.headers_cache = {
+        "file_name": "test.csv",
         "last_modified": "old-date",
         "content_length": "1024",
     }
 
-    with patch.object(connector, "connect", return_value=mock_google_api_client):
-        with patch.object(
-            connector,
-            "_prepare_cache",
-            return_value={"last_modified": "new-date", "content_length": "1024"},
-        ):
-            with patch(
-                "lubrikit.extract.connectors.google_drive_api.MediaIoBaseDownload"
-            ):
-                with patch("lubrikit.extract.connectors.google_drive_api.io.BytesIO"):
-                    _, (stream, downloader) = connector._download()
+    # Mock the properties that _prepare_cache calls - different last_modified
+    mock_client.files().get().execute.side_effect = [
+        {"name": "test.csv"},
+        {"modifiedTime": "new-date"},
+        {"size": "1024"},
+    ]
+
+    with patch.object(connector, "_validate_mime_type"):
+        _, downloader = connector._download()
 
     # Should trigger download
-    assert stream is not None
     assert downloader is not None
+
+    # Reset for test case 2
+    mock_client.reset_mock()
 
     # Test case 2: Different content_length should trigger download
     connector.headers_cache = {
+        "file_name": "test.csv",
         "last_modified": "same-date",
         "content_length": "500",
     }
 
-    with patch.object(connector, "connect", return_value=mock_google_api_client):
-        with patch.object(
-            connector,
-            "_prepare_cache",
-            return_value={"last_modified": "same-date", "content_length": "1024"},
-        ):
-            with patch(
-                "lubrikit.extract.connectors.google_drive_api.MediaIoBaseDownload"
-            ):
-                with patch("lubrikit.extract.connectors.google_drive_api.io.BytesIO"):
-                    _, (stream, downloader) = connector._download()
+    # Mock the properties that _prepare_cache calls - different content_length
+    mock_client.files().get().execute.side_effect = [
+        {"name": "test.csv"},
+        {"modifiedTime": "same-date"},
+        {"size": "1024"},
+    ]
+
+    with patch.object(connector, "_validate_mime_type"):
+        _, downloader = connector._download()
 
     # Should trigger download
-    assert stream is not None
     assert downloader is not None
+
+
+@patch("lubrikit.extract.connectors.google_drive_api.build")
+@patch("lubrikit.extract.connectors.google_drive_api.service_account")
+def test_supported_mime_types_property(
+    mock_service_account: Mock,
+    mock_build: Mock,
+    connector: GoogleDriveAPIConnector,
+) -> None:
+    """Test supported_mime_types property returns sorted list of MIME types."""
+    # Mock the service account credentials
+    mock_credentials = Mock()
+    mock_service_account.Credentials.from_service_account_info.return_value = (
+        mock_credentials
+    )
+    mock_credentials.with_scopes.return_value = mock_credentials
+
+    # Mock the Google API client
+    mock_client = Mock()
+    mock_build.return_value = mock_client
+
+    # Mock the API response with export links
+    mock_client.files().get().execute.return_value = {
+        "exportLinks": {
+            "text/csv": "https://docs.google.com/spreadsheets/export?id=123&format=csv",
+            "application/pdf": "https://docs.google.com/spreadsheets/export?id=123&format=pdf",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "https://docs.google.com/spreadsheets/export?id=123&format=xlsx",
+        }
+    }
+
+    # Get supported MIME types
+    supported_types = connector.supported_mime_types
+
+    # Should return sorted list of MIME types
+    expected_types = [
+        "application/pdf",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "text/csv",
+    ]
+    assert supported_types == expected_types
+
+    # Verify the API was called correctly with the expected parameters
+    mock_client.files().get.assert_any_call(
+        fileId=connector.config.fileId, fields="exportLinks"
+    )
+
+
+@patch("lubrikit.extract.connectors.google_drive_api.build")
+@patch("lubrikit.extract.connectors.google_drive_api.service_account")
+def test_supported_mime_types_empty_export_links(
+    mock_service_account: Mock,
+    mock_build: Mock,
+    connector: GoogleDriveAPIConnector,
+) -> None:
+    """Test supported_mime_types property with empty export links."""
+    # Mock the service account credentials
+    mock_credentials = Mock()
+    mock_service_account.Credentials.from_service_account_info.return_value = (
+        mock_credentials
+    )
+    mock_credentials.with_scopes.return_value = mock_credentials
+
+    # Mock the Google API client
+    mock_client = Mock()
+    mock_build.return_value = mock_client
+
+    # Mock the API response with no export links
+    mock_client.files().get().execute.return_value = {"exportLinks": {}}
+
+    # Get supported MIME types
+    supported_types = connector.supported_mime_types
+
+    # Should return empty list
+    assert supported_types == []
+
+
+@patch("lubrikit.extract.connectors.google_drive_api.build")
+@patch("lubrikit.extract.connectors.google_drive_api.service_account")
+def test_supported_mime_types_missing_export_links(
+    mock_service_account: Mock,
+    mock_build: Mock,
+    connector: GoogleDriveAPIConnector,
+) -> None:
+    """Test supported_mime_types property when exportLinks key is missing."""
+    # Mock the service account credentials
+    mock_credentials = Mock()
+    mock_service_account.Credentials.from_service_account_info.return_value = (
+        mock_credentials
+    )
+    mock_credentials.with_scopes.return_value = mock_credentials
+
+    # Mock the Google API client
+    mock_client = Mock()
+    mock_build.return_value = mock_client
+
+    # Mock the API response without exportLinks key
+    mock_client.files().get().execute.return_value = {}
+
+    # Get supported MIME types
+    supported_types = connector.supported_mime_types
+
+    # Should return empty list when exportLinks key is missing
+    assert supported_types == []
+
+
+@patch("lubrikit.extract.connectors.google_drive_api.build")
+@patch("lubrikit.extract.connectors.google_drive_api.service_account")
+def test_validate_mime_type_success(
+    mock_service_account: Mock,
+    mock_build: Mock,
+    google_drive_config: GoogleDriveAPIConfig,
+    service_account_info: GoogleDriveAPIServiceAccountInfo,
+    headers_cache: dict[str, str],
+) -> None:
+    """Test _validate_mime_type method with valid MIME type."""
+    # Create config with a MIME type
+    config_with_mime = GoogleDriveAPIConfig(
+        fileId=google_drive_config.fileId, mimeType="text/csv"
+    )
+
+    connector = GoogleDriveAPIConnector(
+        config=config_with_mime,
+        service_account_info=service_account_info,
+        headers_cache=headers_cache,
+    )
+
+    # Mock the service account credentials
+    mock_credentials = Mock()
+    mock_service_account.Credentials.from_service_account_info.return_value = (
+        mock_credentials
+    )
+    mock_credentials.with_scopes.return_value = mock_credentials
+
+    # Mock the Google API client
+    mock_client = Mock()
+    mock_build.return_value = mock_client
+
+    # Mock the API response to include the configured MIME type
+    mock_client.files().get().execute.return_value = {
+        "exportLinks": {
+            "text/csv": "https://docs.google.com/spreadsheets/export?id=123&format=csv",
+            "application/pdf": "https://docs.google.com/spreadsheets/export?id=123&format=pdf",
+        }
+    }
+
+    # Should not raise any exception
+    connector._validate_mime_type()
+
+
+@patch("lubrikit.extract.connectors.google_drive_api.build")
+@patch("lubrikit.extract.connectors.google_drive_api.service_account")
+def test_validate_mime_type_invalid(
+    mock_service_account: Mock,
+    mock_build: Mock,
+    google_drive_config: GoogleDriveAPIConfig,
+    service_account_info: GoogleDriveAPIServiceAccountInfo,
+    headers_cache: dict[str, str],
+) -> None:
+    """Test _validate_mime_type method with invalid MIME type."""
+    # Create config with an unsupported MIME type
+    config_with_mime = GoogleDriveAPIConfig(
+        fileId=google_drive_config.fileId, mimeType="unsupported/type"
+    )
+
+    connector = GoogleDriveAPIConnector(
+        config=config_with_mime,
+        service_account_info=service_account_info,
+        headers_cache=headers_cache,
+    )
+
+    # Mock the service account credentials
+    mock_credentials = Mock()
+    mock_service_account.Credentials.from_service_account_info.return_value = (
+        mock_credentials
+    )
+    mock_credentials.with_scopes.return_value = mock_credentials
+
+    # Mock the Google API client
+    mock_client = Mock()
+    mock_build.return_value = mock_client
+
+    # Mock the API response to NOT include the configured MIME type
+    mock_client.files().get().execute.return_value = {
+        "exportLinks": {
+            "text/csv": "https://docs.google.com/spreadsheets/export?id=123&format=csv",
+            "application/pdf": "https://docs.google.com/spreadsheets/export?id=123&format=pdf",
+        }
+    }
+
+    with pytest.raises(ValueError, match="Unsupported MIME type 'unsupported/type'"):
+        connector._validate_mime_type()
+
+
+def test_validate_mime_type_none(
+    google_drive_config: GoogleDriveAPIConfig,
+    service_account_info: GoogleDriveAPIServiceAccountInfo,
+    headers_cache: dict[str, str],
+) -> None:
+    """Test _validate_mime_type method with None MIME type."""
+    # Use config without MIME type (None)
+    connector = GoogleDriveAPIConnector(
+        config=google_drive_config,  # This has mimeType=None
+        service_account_info=service_account_info,
+        headers_cache=headers_cache,
+    )
+
+    # Should not raise any exception and should not check supported types
+    # This should work without any mocking since it returns early when mimeType is None
+    connector._validate_mime_type()
+
+
+@patch("lubrikit.extract.connectors.google_drive_api.build")
+@patch("lubrikit.extract.connectors.google_drive_api.service_account")
+def test_validate_mime_type_error_message(
+    mock_service_account: Mock,
+    mock_build: Mock,
+    google_drive_config: GoogleDriveAPIConfig,
+    service_account_info: GoogleDriveAPIServiceAccountInfo,
+    headers_cache: dict[str, str],
+) -> None:
+    """Test _validate_mime_type method error message includes supported types."""
+    # Create config with an unsupported MIME type
+    config_with_mime = GoogleDriveAPIConfig(
+        fileId=google_drive_config.fileId, mimeType="invalid/format"
+    )
+
+    connector = GoogleDriveAPIConnector(
+        config=config_with_mime,
+        service_account_info=service_account_info,
+        headers_cache=headers_cache,
+    )
+
+    # Mock the service account credentials
+    mock_credentials = Mock()
+    mock_service_account.Credentials.from_service_account_info.return_value = (
+        mock_credentials
+    )
+    mock_credentials.with_scopes.return_value = mock_credentials
+
+    # Mock the Google API client
+    mock_client = Mock()
+    mock_build.return_value = mock_client
+
+    # Mock the API response with specific supported types
+    mock_client.files().get().execute.return_value = {
+        "exportLinks": {
+            "text/csv": "https://docs.google.com/spreadsheets/export?id=123&format=csv",
+            "application/pdf": "https://docs.google.com/spreadsheets/export?id=123&format=pdf",
+            "text/html": "https://docs.google.com/spreadsheets/export?id=123&format=html",
+        }
+    }
+
+    with pytest.raises(ValueError) as exc_info:
+        connector._validate_mime_type()
+
+    error_message = str(exc_info.value)
+    assert "Unsupported MIME type 'invalid/format'" in error_message
+    assert "Supported types: application/pdf, text/csv, text/html" in error_message

--- a/tests/extract/connectors/test_http_connector.py
+++ b/tests/extract/connectors/test_http_connector.py
@@ -272,6 +272,7 @@ def test_download_failure(
 
     headers, response = connector._download()
 
+    # Failed responses should return None for both headers and response
     assert headers is None
     assert response is None
     mock_logger.error.assert_called_once_with(


### PR DESCRIPTION
# Pull Request

## INFO

- Add support for Google Workspace documents (Google Docs, Google Sheets, etc.)
  - Include `mimeType` as an optional variable in the `GoogleDriveAPIConfig`
  - This `mimeType` variable indicates to the Google Drive API what to export the file as
  - For example, a Google Sheets document may have a `mimeType` set to `text/csv` to export it as a CSV file
  - See documentation below for a more complete set of mime types available
- Minor improvements complementary to the scope of this feature

## REFERENCES

- Related issue(s):
  - Closes #22 
- Documentation:
  - [Export MIME types for Google Drive API](https://developers.google.com/workspace/drive/api/guides/ref-export-formats)
