### PR TITLE
#36 - Add extract pipeline

### DIFF
--- a/lubrikit/base/__init__.py
+++ b/lubrikit/base/__init__.py
@@ -1,0 +1,3 @@
+from .pipeline import Pipeline
+
+__all__ = ["Pipeline"]

--- a/lubrikit/base/pipeline.py
+++ b/lubrikit/base/pipeline.py
@@ -1,0 +1,8 @@
+from abc import ABC, abstractmethod
+
+
+class Pipeline(ABC):
+    @abstractmethod
+    def run(self) -> None:
+        """Runs the pipeline process."""
+        ...

--- a/lubrikit/extract/connectors/__init__.py
+++ b/lubrikit/extract/connectors/__init__.py
@@ -1,4 +1,5 @@
+from .base import BaseConnector
 from .google_drive_api import GoogleDriveAPIConnector
 from .http_connector import HTTPConnector
 
-__all__ = ["HTTPConnector", "GoogleDriveAPIConnector"]
+__all__ = ["BaseConnector", "HTTPConnector", "GoogleDriveAPIConnector"]

--- a/lubrikit/extract/connectors/base.py
+++ b/lubrikit/extract/connectors/base.py
@@ -9,6 +9,8 @@ class BaseConnector(ABC):
         self,
         headers_cache: dict[str, str] | None = None,
         retry_config: dict[str, Any] | None = None,
+        *args: Any,
+        **kwargs: Any,
     ) -> None:
         self.headers_cache: dict[str, str] = headers_cache or {}
         self.retry_config = (

--- a/lubrikit/extract/connectors/google_drive_api.py
+++ b/lubrikit/extract/connectors/google_drive_api.py
@@ -264,17 +264,18 @@ class GoogleDriveAPIConnector(BaseConnector):
 
     api_name: str = "drive"  # Google API service name for Drive API
     api_version: str = "v3"  # Google Drive API version
-    scopes = [
-        "https://www.googleapis.com/auth/drive"
-    ]  # OAuth2 scopes for full Drive access
+    scopes = ["https://www.googleapis.com/auth/drive"]  # OAuth2 scopes for Drive access
 
     def __init__(
         self,
-        config: dict[str, Any],
-        service_account_info: GoogleDriveAPIServiceAccountInfo | None = None,
         headers_cache: dict[str, str] | None = None,
         retry_config: dict[str, Any] | None = None,
+        config: dict[str, Any] | None = None,
+        service_account_info: GoogleDriveAPIServiceAccountInfo | None = None,
     ):
+        if not config:
+            raise ValueError("GoogleDriveAPIConnector requires a configuration.")
+
         super().__init__(headers_cache, retry_config)
 
         # Configuration object containing file ID and connection parameters

--- a/lubrikit/extract/connectors/http_connector.py
+++ b/lubrikit/extract/connectors/http_connector.py
@@ -36,9 +36,12 @@ class HTTPConnector(BaseConnector):
     def __init__(
         self,
         headers_cache: dict[str, str],
-        config: dict[str, Any],
         retry_config: dict[str, Any] | None = None,
+        config: dict[str, Any] | None = None,
     ) -> None:
+        if not config:
+            raise ValueError("HTTPConnector requires a configuration.")
+
         super().__init__(headers_cache, retry_config)
 
         # Configuration object containing HTTP request parameters

--- a/lubrikit/extract/pipeline.py
+++ b/lubrikit/extract/pipeline.py
@@ -1,0 +1,44 @@
+from functools import cached_property
+from typing import Any, cast
+
+from lubrikit.base import Pipeline
+from lubrikit.extract import connectors
+from lubrikit.extract.storage import ExtractStorageClient, FileMetadata
+
+
+class ExtractPipeline(Pipeline):
+    def __init__(self, metadata: dict[str, Any]) -> None:
+        self.metadata: FileMetadata = cast(FileMetadata, metadata)
+
+    @cached_property
+    def client(self) -> ExtractStorageClient:
+        """Return the ExtractStorageClient instance."""
+        return ExtractStorageClient(self.metadata)
+
+    @property
+    def connector(self) -> type[connectors.BaseConnector]:
+        """Return the connector class based on the metadata."""
+        Connector: type[connectors.BaseConnector] | None = getattr(
+            connectors, self.metadata["connector"], None
+        )
+        if not Connector:
+            raise ValueError(f"Connector {self.metadata['connector']} not found.")
+
+        return Connector
+
+    def run(self) -> None:
+        """Runs the extract pipeline.
+
+        Executes the pipeline process by initializing the connector,
+        downloading data, and writing the downloaded data using the
+        storage client.
+        """
+        connector = self.connector(
+            config=self.metadata.get("connector_config"),
+            headers_cache=self.metadata.get("headers_cache"),
+            retry_config=self.metadata.get("retry_config"),
+        )
+
+        _, downloader = connector.download()
+        if downloader:
+            self.client.write(downloader)

--- a/lubrikit/extract/storage/__init__.py
+++ b/lubrikit/extract/storage/__init__.py
@@ -1,3 +1,4 @@
 from .client import ExtractStorageClient
+from .file_metadata import FileMetadata
 
-__all__ = ["ExtractStorageClient"]
+__all__ = ["ExtractStorageClient", "FileMetadata"]

--- a/lubrikit/extract/storage/client.py
+++ b/lubrikit/extract/storage/client.py
@@ -94,7 +94,7 @@ class ExtractStorageClient(StorageClient):
         """Write a requests.Response object to storage.
 
         Args:
-            data (Response): The Response object to write.
+            downloader (Response): The Response object to write.
         """
         downloader.raise_for_status()
 

--- a/lubrikit/extract/storage/client.py
+++ b/lubrikit/extract/storage/client.py
@@ -3,6 +3,7 @@ import os
 from functools import singledispatchmethod
 from typing import Any
 
+from googleapiclient.http import MediaIoBaseDownload
 from requests import Response
 
 from lubrikit.base.storage import (
@@ -50,29 +51,61 @@ class ExtractStorageClient(StorageClient):
         return "/".join(path_components)
 
     @singledispatchmethod
-    def write(self, data: Any) -> None:
+    def write(self, downloader: Any) -> None:
         """Write data to storage.
 
         Args:
-            data (Any): The data to write.
+            downloader (Any): The downloader to retrieve data to write.
         Raises:
             NotImplementedError: If the data type is not supported.
         """
-        raise NotImplementedError(f"Write not implemented for type {type(data)}")
+        raise NotImplementedError(f"Write not implemented for type {type(downloader)}")
 
     @write.register
-    def _(self, data: Response) -> None:
+    def _(self, downloader: MediaIoBaseDownload) -> None:
+        """Writes a MediaIoBaseDownload's downloaded content to storage.
+
+        The method ensures the output directory exists before writing
+        the file. The downloaded data is accessed from the internal file
+        descriptor of the downloader.
+
+        Args:
+            downloader (MediaIoBaseDownload): The downloader object used
+                to fetch the file chunks.
+        """
+        output_path: str = self.get_path(self.metadata)
+        self._make_dirs(path=self.get_folder())
+
+        # Download the file
+        done = False
+        while not done:
+            _, done = downloader.next_chunk()
+
+        # Access the downloaded data
+        file_handle = downloader._fd  # The BytesIO object
+        file_handle.seek(0)  # Reset to beginning
+
+        # Stream to final destination
+        with open(output_path, FileMode.WRITING_BINARY) as f:
+            f.write(file_handle.read())
+
+    @write.register
+    def _(self, downloader: Response) -> None:
         """Write a requests.Response object to storage.
 
         Args:
             data (Response): The Response object to write.
         """
-        data.raise_for_status()
+        downloader.raise_for_status()
 
         output_path: str = self.get_path(self.metadata)
         self._make_dirs(path=self.get_folder())
 
-        logger.info(f"Writing {data.headers['Content-Length']} bytes to {output_path}")
+        logger.info(
+            f"Writing {downloader.headers['Content-Length']} bytes to {output_path}"
+        )
         with open(output_path, FileMode.WRITING_BINARY) as f:
-            for chunk in data.iter_content(chunk_size=ExtractStorageClient.chunk_size):
+            for chunk in downloader.iter_content(
+                chunk_size=ExtractStorageClient.chunk_size
+            ):
                 f.write(chunk)

--- a/tests/base/test_pipeline.py
+++ b/tests/base/test_pipeline.py
@@ -1,0 +1,46 @@
+import pytest
+
+from lubrikit.base import Pipeline
+
+
+def test_pipeline_is_abstract_base_class() -> None:
+    """Test that Pipeline is an abstract base class."""
+    # Pipeline cannot be instantiated directly due to abstract run method
+    with pytest.raises(TypeError, match="Can't instantiate abstract class Pipeline"):
+        Pipeline()  # type: ignore[abstract]
+
+
+def test_pipeline_inheritance() -> None:
+    """Test that Pipeline can be properly inherited."""
+
+    class ConcretePipeline(Pipeline):
+        def run(self) -> None:
+            pass
+
+    # Should be able to instantiate a concrete implementation
+    pipeline = ConcretePipeline()
+    assert isinstance(pipeline, Pipeline)
+
+
+def test_pipeline_has_abc_base() -> None:
+    """Test that Pipeline inherits from ABC."""
+    from abc import ABC
+
+    assert issubclass(Pipeline, ABC)
+
+
+def test_pipeline_concrete_implementation() -> None:
+    """Test a concrete Pipeline implementation."""
+
+    class TestPipeline(Pipeline):
+        def __init__(self) -> None:
+            self.executed = False
+
+        def run(self) -> None:
+            self.executed = True
+
+    pipeline = TestPipeline()
+    assert not pipeline.executed
+
+    pipeline.run()
+    assert pipeline.executed

--- a/tests/extract/connectors/test_http_connector.py
+++ b/tests/extract/connectors/test_http_connector.py
@@ -35,7 +35,7 @@ def connector(
     headers_cache: dict[str, str], http_config: dict[str, Any]
 ) -> HTTPConnector:
     """HTTPConnector instance with default configuration."""
-    return HTTPConnector(headers_cache, http_config)
+    return HTTPConnector(headers_cache=headers_cache, config=http_config)
 
 
 @pytest.fixture
@@ -45,7 +45,9 @@ def connector_with_retry(
     retry_config: dict[str, int | float],
 ) -> HTTPConnector:
     """HTTPConnector instance with retry configuration."""
-    return HTTPConnector(headers_cache, http_config, retry_config)
+    return HTTPConnector(
+        headers_cache=headers_cache, config=http_config, retry_config=retry_config
+    )
 
 
 @pytest.mark.parametrize(
@@ -62,7 +64,7 @@ def test_initialization_default(
     expected: int | float,
 ) -> None:
     """Test HTTPConnector initialization with default retry config."""
-    connector = HTTPConnector(headers_cache, http_config)
+    connector = HTTPConnector(headers_cache=headers_cache, config=http_config)
 
     assert getattr(connector.retry_config, feature) == expected
 
@@ -73,7 +75,9 @@ def test_initialization_with_retry_config(
     retry_config: dict[str, int | float],
 ) -> None:
     """Test HTTPConnector initialization with custom retry config."""
-    connector = HTTPConnector(headers_cache, http_config, retry_config)
+    connector = HTTPConnector(
+        headers_cache=headers_cache, config=http_config, retry_config=retry_config
+    )
 
     assert connector.headers_cache == headers_cache
     assert connector.config == HTTPConfig(**http_config)
@@ -224,7 +228,7 @@ def test_download_unchanged_content(mock_logger: Mock, mock_request: Mock) -> No
         "method": "GET",
         "url": "https://api.example.com/data",
     }
-    connector = HTTPConnector(headers_cache, config)
+    connector = HTTPConnector(headers_cache=headers_cache, config=config)
 
     mock_response = Mock(spec=requests.Response)
     mock_response.ok = True
@@ -284,7 +288,7 @@ def test_post_request_with_form_data(mock_request: Mock) -> None:
         "data": {"username": "test", "password": "secret"},
         "extra_headers": {"Content-Type": "application/x-www-form-urlencoded"},
     }
-    connector = HTTPConnector(headers_cache, config)
+    connector = HTTPConnector(headers_cache=headers_cache, config=config)
 
     mock_response = Mock(spec=requests.Response)
     mock_response.ok = True
@@ -318,7 +322,7 @@ def test_post_request_with_json_data(mock_request: Mock) -> None:
         "json_data": {"name": "John Doe", "email": "john@example.com"},
         "extra_headers": {"Content-Type": "application/json"},
     }
-    connector = HTTPConnector(headers_cache, config)
+    connector = HTTPConnector(headers_cache=headers_cache, config=config)
 
     mock_response = Mock(spec=requests.Response)
     mock_response.ok = True
@@ -380,7 +384,7 @@ def test_headers_update_with_extra_headers(mock_request: Mock) -> None:
         "url": "https://api.example.com/data",
         "extra_headers": {"User-Agent": "TestBot/2.0", "Accept": "application/json"},
     }
-    connector = HTTPConnector(headers_cache, config)
+    connector = HTTPConnector(headers_cache=headers_cache, config=config)
 
     mock_response = Mock(spec=requests.Response)
     mock_response.ok = True
@@ -408,7 +412,7 @@ def test_empty_headers_cache_initialization() -> None:
     """Test HTTPConnector with empty headers cache."""
     headers_cache: dict[str, str] = {}
     config = {"method": "GET", "url": "https://example.com"}
-    connector = HTTPConnector(headers_cache, config)
+    connector = HTTPConnector(headers_cache=headers_cache, config=config)
 
     assert connector.headers_cache == {}
     assert connector.config == HTTPConfig(**config)
@@ -418,7 +422,7 @@ def test_no_extra_headers_config() -> None:
     """Test HTTPConnector with no extra headers in config."""
     headers_cache = {"User-Agent": "Default/1.0"}
     config = {"method": "GET", "url": "https://example.com"}
-    connector = HTTPConnector(headers_cache, config)
+    connector = HTTPConnector(headers_cache=headers_cache, config=config)
 
     assert connector.config.extra_headers is None
 
@@ -435,7 +439,7 @@ def test_http_methods(
 ) -> None:
     """Test that different HTTP methods are properly handled."""
     config = {"method": method, "url": "https://example.com"}
-    connector = HTTPConnector(headers_cache, config)
+    connector = HTTPConnector(headers_cache=headers_cache, config=config)
 
     assert connector.config.method == expected_method
 
@@ -451,6 +455,6 @@ def test_http_methods(
 def test_various_urls(url: str, headers_cache: dict[str, str]) -> None:
     """Test that various URL formats are properly handled."""
     config = {"method": "GET", "url": url}
-    connector = HTTPConnector(headers_cache, config)
+    connector = HTTPConnector(headers_cache=headers_cache, config=config)
 
     assert connector.config.url == url

--- a/tests/extract/test_pipeline.py
+++ b/tests/extract/test_pipeline.py
@@ -1,0 +1,320 @@
+from typing import Any
+from unittest.mock import Mock, patch
+
+import pytest
+from googleapiclient.http import MediaIoBaseDownload
+from requests import Response
+
+from lubrikit.extract.connectors import GoogleDriveAPIConnector, HTTPConnector
+from lubrikit.extract.pipeline import ExtractPipeline
+from lubrikit.extract.storage import ExtractStorageClient
+
+
+@pytest.fixture
+def http_metadata() -> dict[str, Any]:
+    """Sample metadata for HTTPConnector."""
+    return {
+        "connector": "HTTPConnector",
+        "connector_config": {
+            "url": "https://api.example.com/data.json",
+            "method": "GET",
+        },
+        "headers_cache": {},
+        "prefix": "api_data",
+        "source_name": "test_api",
+        "created_at": "2024-01-01T00:00:00",
+        "modified_at": "2024-01-01T00:00:00",
+    }
+
+
+@pytest.fixture
+def gdrive_metadata() -> dict[str, Any]:
+    """Sample metadata for GoogleDriveAPIConnector."""
+    return {
+        "connector": "GoogleDriveAPIConnector",
+        "connector_config": {"fileId": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms"},
+        "headers_cache": {},
+        "prefix": "gdrive_files",
+        "source_name": "google_drive",
+        "created_at": "2024-01-01T00:00:00",
+        "modified_at": "2024-01-01T00:00:00",
+    }
+
+
+def test_init_with_http_metadata(http_metadata: dict[str, Any]) -> None:
+    """Test ExtractPipeline initialization with HTTP metadata."""
+    pipeline = ExtractPipeline(http_metadata)
+
+    assert isinstance(pipeline.metadata, dict)
+    assert pipeline.metadata["connector"] == "HTTPConnector"
+    assert pipeline.metadata["source_name"] == "test_api"
+    assert pipeline.metadata["prefix"] == "api_data"
+
+
+def test_init_with_gdrive_metadata(gdrive_metadata: dict[str, Any]) -> None:
+    """Test ExtractPipeline initialization with Google Drive metadata."""
+    pipeline = ExtractPipeline(gdrive_metadata)
+
+    assert isinstance(pipeline.metadata, dict)
+    assert pipeline.metadata["connector"] == "GoogleDriveAPIConnector"
+    assert pipeline.metadata["source_name"] == "google_drive"
+    assert pipeline.metadata["prefix"] == "gdrive_files"
+
+
+def test_client_property(http_metadata: dict[str, Any]) -> None:
+    """Test client property returns ExtractStorageClient."""
+    pipeline = ExtractPipeline(http_metadata)
+
+    client = pipeline.client
+    assert isinstance(client, ExtractStorageClient)
+    assert client.metadata == pipeline.metadata
+
+
+def test_client_cached_property(http_metadata: dict[str, Any]) -> None:
+    """Test client property is cached."""
+    pipeline = ExtractPipeline(http_metadata)
+
+    client1 = pipeline.client
+    client2 = pipeline.client
+
+    # Should be the same instance due to @cached_property
+    assert client1 is client2
+
+
+def test_connector_property_http(http_metadata: dict[str, Any]) -> None:
+    """Test connector property returns HTTPConnector class."""
+    pipeline = ExtractPipeline(http_metadata)
+
+    connector_class = pipeline.connector
+    assert connector_class is HTTPConnector
+    assert issubclass(connector_class, HTTPConnector)
+
+
+def test_connector_property_gdrive(gdrive_metadata: dict[str, Any]) -> None:
+    """Test connector property returns GoogleDriveAPIConnector class."""
+    pipeline = ExtractPipeline(gdrive_metadata)
+
+    connector_class = pipeline.connector
+    assert connector_class is GoogleDriveAPIConnector
+    assert issubclass(connector_class, GoogleDriveAPIConnector)
+
+
+def test_connector_property_invalid_connector() -> None:
+    """Test connector property with invalid connector name."""
+    invalid_metadata = {
+        "connector": "InvalidConnector",
+        "connector_config": "{}",
+        "created_at": "2024-01-01T00:00:00",
+        "modified_at": "2024-01-01T00:00:00",
+    }
+
+    pipeline = ExtractPipeline(invalid_metadata)
+
+    with pytest.raises(ValueError, match="Connector InvalidConnector not found"):
+        _ = pipeline.connector
+
+
+@patch("lubrikit.extract.pipeline.connectors")
+def test_connector_property_none_connector(
+    mock_connectors: Mock, http_metadata: dict[str, Any]
+) -> None:
+    """Test connector property when getattr returns None."""
+    mock_connectors.HTTPConnector = None
+
+    pipeline = ExtractPipeline(http_metadata)
+
+    with pytest.raises(ValueError, match="Connector HTTPConnector not found"):
+        _ = pipeline.connector
+
+
+@patch.object(ExtractStorageClient, "write")
+@patch("lubrikit.extract.connectors.HTTPConnector")
+def test_run_with_http_connector_success(
+    mock_http_connector: Mock, mock_write: Mock, http_metadata: dict[str, Any]
+) -> None:
+    """Test run method with HTTPConnector returning data."""
+    pipeline = ExtractPipeline(http_metadata)
+
+    # Mock the connector and its download method
+    mock_response = Mock(spec=Response)
+    mock_headers = {"etag": "abc123", "content_length": "1024"}
+
+    mock_connector_instance = Mock()
+    mock_connector_instance.download.return_value = (mock_headers, mock_response)
+    mock_http_connector.return_value = mock_connector_instance
+
+    pipeline.run()
+
+    # Verify connector was instantiated with correct parameters
+    mock_http_connector.assert_called_once_with(
+        config=pipeline.metadata.get("connector_config"),
+        headers_cache=pipeline.metadata.get("headers_cache"),
+        retry_config=pipeline.metadata.get("retry_config"),
+    )
+
+    # Verify download was called
+    mock_connector_instance.download.assert_called_once()
+
+    # Verify write was called with the response
+    mock_write.assert_called_once_with(mock_response)
+
+
+@patch.object(ExtractStorageClient, "write")
+@patch("lubrikit.extract.connectors.GoogleDriveAPIConnector")
+def test_run_with_gdrive_connector_success(
+    mock_gdrive_connector: Mock, mock_write: Mock, gdrive_metadata: dict[str, Any]
+) -> None:
+    """Test run method with GoogleDriveAPIConnector returning data."""
+    pipeline = ExtractPipeline(gdrive_metadata)
+
+    # Mock the connector and its download method
+    mock_downloader = Mock(spec=MediaIoBaseDownload)
+    mock_headers = {"file_name": "test.xlsx", "last_modified": "2024-01-01T00:00:00Z"}
+
+    mock_connector_instance = Mock()
+    mock_connector_instance.download.return_value = (mock_headers, mock_downloader)
+    mock_gdrive_connector.return_value = mock_connector_instance
+
+    pipeline.run()
+
+    # Verify connector was instantiated with correct parameters
+    mock_gdrive_connector.assert_called_once_with(
+        config=pipeline.metadata.get("connector_config"),
+        headers_cache=pipeline.metadata.get("headers_cache"),
+        retry_config=pipeline.metadata.get("retry_config"),
+    )
+
+    # Verify download was called
+    mock_connector_instance.download.assert_called_once()
+
+    # Verify write was called with the downloader
+    mock_write.assert_called_once_with(mock_downloader)
+
+
+@patch.object(ExtractStorageClient, "write")
+@patch("lubrikit.extract.connectors.HTTPConnector")
+def test_run_with_no_data_to_download(
+    mock_http_connector: Mock, mock_write: Mock, http_metadata: dict[str, Any]
+) -> None:
+    """Test run method when connector returns None (no new data)."""
+    pipeline = ExtractPipeline(http_metadata)
+
+    mock_headers = {"etag": "abc123"}
+
+    mock_connector_instance = Mock()
+    # Connector returns None when no new data is available
+    mock_connector_instance.download.return_value = (mock_headers, None)
+    mock_http_connector.return_value = mock_connector_instance
+
+    pipeline.run()
+
+    # Verify connector was called
+    mock_http_connector.assert_called_once()
+    mock_connector_instance.download.assert_called_once()
+
+    # Verify write was NOT called since downloader is None
+    mock_write.assert_not_called()
+
+
+@patch.object(ExtractStorageClient, "write")
+@patch("lubrikit.extract.connectors.HTTPConnector")
+def test_run_with_false_downloader(
+    mock_http_connector: Mock, mock_write: Mock, http_metadata: dict[str, Any]
+) -> None:
+    """Test run method when connector returns falsy downloader."""
+    pipeline = ExtractPipeline(http_metadata)
+
+    mock_headers = {"etag": "abc123"}
+
+    mock_connector_instance = Mock()
+    # Connector returns empty string (falsy value)
+    mock_connector_instance.download.return_value = (mock_headers, "")
+    mock_http_connector.return_value = mock_connector_instance
+
+    pipeline.run()
+
+    # Verify write was NOT called since downloader is falsy
+    mock_write.assert_not_called()
+
+
+@patch("lubrikit.extract.connectors.HTTPConnector")
+def test_run_connector_instantiation_parameters(
+    mock_http_connector: Mock, http_metadata: dict[str, Any]
+) -> None:
+    """Test that connector is instantiated with correct parameters."""
+    pipeline = ExtractPipeline(http_metadata)
+
+    mock_connector_instance = Mock()
+    mock_connector_instance.download.return_value = ({}, None)
+    mock_http_connector.return_value = mock_connector_instance
+
+    pipeline.run()
+
+    # Verify the exact parameters passed to connector
+    mock_http_connector.assert_called_once_with(
+        config=pipeline.metadata.get("connector_config"),
+        headers_cache=pipeline.metadata.get("headers_cache"),
+        retry_config=pipeline.metadata.get("retry_config"),
+    )
+
+
+def test_inheritance_from_base_pipeline(http_metadata: dict[str, Any]) -> None:
+    """Test that ExtractPipeline properly inherits from Pipeline."""
+    from lubrikit.base import Pipeline
+
+    pipeline = ExtractPipeline(http_metadata)
+    assert isinstance(pipeline, Pipeline)
+
+
+def test_run_method_exists(http_metadata: dict[str, Any]) -> None:
+    """Test that run method is properly implemented."""
+    pipeline = ExtractPipeline(http_metadata)
+    assert hasattr(pipeline, "run")
+    assert callable(pipeline.run)
+
+
+@patch.object(ExtractStorageClient, "write")
+@patch("lubrikit.extract.connectors.HTTPConnector")
+def test_run_end_to_end_flow(
+    mock_http_connector: Mock, mock_write: Mock, http_metadata: dict[str, Any]
+) -> None:
+    """Test complete run flow from start to finish."""
+    pipeline = ExtractPipeline(http_metadata)
+
+    # Setup mocks
+    mock_response = Mock(spec=Response)
+    mock_headers = {"etag": "def456", "content_length": "2048"}
+
+    mock_connector_instance = Mock()
+    mock_connector_instance.download.return_value = (mock_headers, mock_response)
+    mock_http_connector.return_value = mock_connector_instance
+
+    # Execute the pipeline
+    pipeline.run()
+
+    # Verify the complete flow
+    assert mock_http_connector.called
+    assert mock_connector_instance.download.called
+    assert mock_write.called
+
+    # Verify the data flow
+    call_args = mock_write.call_args
+    assert call_args[0][0] is mock_response  # First positional argument
+
+
+def test_metadata_conversion_types() -> None:
+    """Test that metadata is properly converted to appropriate types."""
+    string_metadata = {
+        "connector": "HTTPConnector",
+        "connector_config": {},
+        "headers_cache": {},
+        "created_at": "2024-01-01T00:00:00",
+        "modified_at": "2024-01-01T00:00:00",
+    }
+
+    pipeline = ExtractPipeline(string_metadata)
+
+    # Should be able to access as FileMetadata
+    assert pipeline.metadata["connector"] == "HTTPConnector"
+    assert isinstance(pipeline.metadata["connector_config"], dict)
+    assert isinstance(pipeline.metadata["headers_cache"], dict)


### PR DESCRIPTION
# Pull Request

## INFO

- What does this PR do?
  - Add `ExtractPipeline`, a prescriptive way to build data extraction pipelines
  - Add `Pipeline`, an abstract base pipeline from which all prescriptive pipelines in this project inherit

## REFERENCES

- Related issue(s):
  - Closes #36 